### PR TITLE
fix error handling (not same password)

### DIFF
--- a/routes/router.js
+++ b/routes/router.js
@@ -15,7 +15,6 @@ router.post('/', function (req, res, next) {
   if (req.body.password !== req.body.passwordConf) {
     var err = new Error('Passwords do not match.');
     err.status = 400;
-    res.send("passwords dont match");
     return next(err);
   }
 


### PR DESCRIPTION
shouldn't use res.send('..') here because the app error handler will send the error message for us. If use here will cause error.